### PR TITLE
chore(security): bumpear apache-airflow a 3.2.0

### DIFF
--- a/Code_Final/requirements.txt
+++ b/Code_Final/requirements.txt
@@ -1,4 +1,4 @@
-apache-airflow==3.1.8
+apache-airflow==3.2.0
 pandas>=2.1.0
 numpy>=1.26.0
 requests>=2.32.0


### PR DESCRIPTION
Cierra los 6 avisos de Dependabot sobre apache-airflow < 3.2.0.

```
- apache-airflow==3.1.8
+ apache-airflow==3.2.0
```

Severities: 1 critical, 2 high, 3 medium.